### PR TITLE
N-gram analysis

### DIFF
--- a/include/attacks/ngram.h
+++ b/include/attacks/ngram.h
@@ -1,0 +1,21 @@
+#ifndef NGRAM_H
+#define NGRAM_H
+
+class Ngram : public Module {
+    public:
+        Ngram();
+
+        // here is a helper func that I will use
+        void test();
+
+        // here are the funcs I need to override
+        void disp_desc();
+        int run();
+
+		int process_input(ifstream* in, vector< int >* charCounts, const int blockSize, const int charSetSize);
+		int analyze_input(vector< vector<int> >* charCounts, vector<int>* charTotal, vector<int>* maxLength, vector<int>* maxCount);
+		int process_output(ofstream * out, vector<vector<int>>* charCounts, vector<int>* charTotal, vector<int>* maxLength);
+		int sort_arrays(vector<int>* charCounts, vector<int>* charIndexArray);
+};
+
+#endif

--- a/include/attacks/ngram.h
+++ b/include/attacks/ngram.h
@@ -13,9 +13,8 @@ class Ngram : public Module {
         int run();
 
 		int process_input(ifstream* in, vector< int >* charCounts, const int blockSize, const int charSetSize);
-		int analyze_input(vector< vector<int> >* charCounts, vector<int>* charTotal, vector<int>* maxLength, vector<int>* maxCount);
-		int process_output(ofstream * out, vector<vector<int>>* charCounts, vector<int>* charTotal, vector<int>* maxLength);
-		int sort_arrays(vector<int>* charCounts, vector<int>* charIndexArray);
+		int process_output(ofstream* out, vector<int>* charCounts, const int charSetSize);
+		string conv_int_to_hex(int input);
 };
 
 #endif

--- a/include/main.h
+++ b/include/main.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <sstream>
 #include <fstream>
+#include <cmath>
 #include <ctype.h>
 
 using namespace std;
@@ -22,6 +23,7 @@ using namespace std;
 /* define inclusions of modules here */
 #include "attacks/example.h"
 #include "attacks/histogram.h"
+#include "attacks/ngram.h"
 #include "attacks/caesar_attack.h"
 #include "ciphers/caesar.h"
 #include "ciphers/vigenere.h"

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CFLAGS=-std=c++11 -Wall -g -Iinclude/
 SD=src/
 ID=include/
 BD=build/
-ATTACKS=example.o histogram.o caesar_attack.o
+ATTACKS=example.o histogram.o caesar_attack.o ngram.o
 CIPHERS=caesar.o vigenere.o
 VER=0.1
 TARG=cryptoproject
@@ -32,6 +32,9 @@ vigenere.o: bd $(SD)ciphers/vigenere.cpp $(ID)ciphers/vigenere.h
 
 caesar_attack.o: bd $(SD)attacks/caesar_attack.cpp $(ID)attacks/caesar_attack.h
 	$(CC) $(CFLAGS) -c $(SD)attacks/caesar_attack.cpp -o $(BD)caesar_attack.o
+	
+ngram.o: bd $(SD)attacks/ngram.cpp $(ID)attacks/ngram.h
+	$(CC) $(CFLAGS) -c $(SD)attacks/ngram.cpp -o $(BD)ngram.o 
 
 $(TARG): main.o module.o $(ATTACKS) $(CIPHERS) $(TOOLS)
 	$(CC) $(CFLAGS) $(BD)main.o $(BD)module.o $(addprefix $(BD), $(ATTACKS)) $(addprefix $(BD), $(CIPHERS)) -o $(TARG)

--- a/src/attacks/histogram.cpp
+++ b/src/attacks/histogram.cpp
@@ -95,7 +95,7 @@ int Histogram::process_input(ifstream* in, vector< vector<int> >* charCounts, co
 	while (!in->eof()) {
 		in->get(inChar);
 		charIndex = ((inChar < 0) ? (charSetSize + (int)inChar) : (int)inChar);
-		if (inChar < 0 || inChar > charSetSize) {
+		if (charIndex < 0 || charIndex > charSetSize) {
 			cout << "[-] Character set size option is smaller than actual size." << endl;
 			return 4;
 		}

--- a/src/attacks/ngram.cpp
+++ b/src/attacks/ngram.cpp
@@ -98,7 +98,7 @@ int Ngram::process_input(ifstream* in, vector< int >* charCounts, const int nSiz
 			return 4;
 		}
 
-		charBuffer[bufferIndex] = inChar;
+		charBuffer[bufferIndex] = charIndex;
 		int arrayIndex = 0;
 		for (int i = 0; i < nSize; i++) {
 			arrayIndex += charBuffer[(bufferIndex + (i + 1)) % nSize] * pow(charSetSize, nSize - (i + 1));

--- a/src/attacks/ngram.cpp
+++ b/src/attacks/ngram.cpp
@@ -1,0 +1,190 @@
+#include "main.h"
+
+/* example constructor, sets some options */
+Ngram::Ngram()
+{
+    // declare options, keep options as uppercase
+    vector<string> temp;
+    temp.push_back("INPUTFILE");
+    temp.push_back("OUTPUTFILE");
+	temp.push_back("N-SIZE");
+	temp.push_back("CHARSETSIZE");
+	temp.push_back("MIN_OCCURENCES");
+    set_opts(temp);
+
+    // set default values, option must exist or error will printed
+	set_opt_value("INPUTFILE", "makefile");
+    set_opt_value("OUTPUTFILE", "ngram");
+	set_opt_value("N-SIZE", "2");
+	set_opt_value("CHARSETSIZE", "256");
+	set_opt_value("MIN_OCCURENCES", "20");
+}
+
+/* helper function that doesn't really do anything */
+void Ngram::test()
+{
+    cout << "example test" << endl;
+}
+
+/* I am overriding the default module function
+ * for displaying the description text
+ */
+void Ngram::disp_desc()
+{
+	cout << "Module: attacks/ngram\n\tThis module aids in the generation of N-gram counts to identify likely.\n\tOutput is generated in a CSV format of \"VALUE,OCCURENCES;\"\n\tThe N-SIZE option is used to determine the number of contiguous letters to consider. Space requirement grows quadratically in the n-gram length.\n\tThe CHARSETSIZE option is used to set the maximum range of the n-gram analysis.\n\t" << endl;
+    disp_opts();
+    cout << endl;
+}
+
+int Ngram::run()
+{
+    // perform error checking on options first
+    if (options["INPUTFILE"].empty()) {
+        cout << "[-] Please specify an input file" << endl;
+        return 1;
+    }
+
+    if (options["OUTPUTFILE"].empty()) {
+        cout << "[-] Please specify an output file" << endl;
+        return 2;
+    }
+
+	const int nSize = stoi(options["N-SIZE"]);
+	const int charSetSize = stoi(options["CHARSETSIZE"]);
+
+	if (nSize < 1){
+		cout << "[-] N-SIZE should be greater than 0" << endl;
+		return 3;
+	}
+
+	vector<int> charCounts;
+	charCounts.resize(pow(charSetSize, nSize));
+
+	ifstream in;
+    ofstream out;
+    string buff;
+
+	if (process_input(&in, &charCounts, nSize, charSetSize) != 0) {
+		return 4;
+	}
+
+	//vector<int> charTotal(nSize), maxLength(nSize), maxCount(nSize);
+	//analyze_input(&charCounts, &charTotal, &maxLength, &maxCount);
+	
+	//process_output(&out, &charCounts, &charTotal, &maxLength);
+
+    cout << "[*] Closing files" << endl;
+    in.close();
+    out.close();
+
+    return 0;
+}
+
+int Ngram::process_input(ifstream* in, vector< int >* charCounts, const int nSize, const int charSetSize) {
+	cout << "[*] Opening file: " << options["INPUTFILE"] << endl;
+	in->open(options["INPUTFILE"]);
+
+
+	cout << "[*] Processing input file..." << endl;
+	char inChar;
+	int bufferIndex = 0, blockIndex = 0, charIndex;
+	vector<int> charBuffer(nSize);
+	while (!in->eof()) {
+		in->get(inChar);
+		charIndex = ((inChar < 0) ? (charSetSize + (int)inChar) : (int)inChar);
+		if (inChar < 0 || inChar > charSetSize) {
+			cout << "[-] Character set size option is smaller than actual size." << endl;
+			return 4;
+		}
+
+		charBuffer[bufferIndex] = inChar;
+		for (int i = 0; i < nSize; i++) {
+			cout << (char)charBuffer[(bufferIndex + (i + 1)) % nSize];
+		}
+		cout << endl;
+
+		//(*charCounts)[]
+
+
+		bufferIndex = ((bufferIndex + 1) % nSize);
+
+
+		//(*charCounts)[blockIndex][charIndex]++;
+		//blockIndex = (blockIndex + 1) % nSize;
+	}
+
+	return 0;
+}
+
+int Ngram::analyze_input(vector< vector<int> >* charCounts, vector<int>* charTotal, vector<int>* maxLength, vector<int>* maxCount) {
+	cout << "[*] Analyzing input..." << endl;
+
+	for (unsigned int blockIndex = 0; blockIndex < charCounts->size(); blockIndex++) {
+		for (unsigned int charIndex = 0; charIndex < (*charCounts)[blockIndex].size(); charIndex++) {
+			int temp = (*charCounts)[blockIndex][charIndex];
+			(*charTotal)[blockIndex] += temp;
+			if (temp > (*maxCount)[blockIndex]) (*maxCount)[blockIndex] = temp;
+		}
+
+		int maxCtCopy = (*maxCount)[blockIndex];
+		while (maxCtCopy /= 10) (*maxLength)[blockIndex]++;
+	}
+
+	return 0;
+}
+
+int Ngram::process_output(ofstream* out, vector< vector<int> >* charCounts, vector<int>* charTotal, vector<int>* maxLength) {
+	vector<int> charIndexRef;
+	charIndexRef.resize((*charCounts)[0].size());
+	for (unsigned int charIndex = 0; charIndex < charIndexRef.size(); charIndex++) {
+		charIndexRef[charIndex] = charIndex;
+	}
+
+	cout << "[*] Opening file: " << options["OUTPUTFILE"] << endl;
+	out->open(options["OUTPUTFILE"]);
+
+	cout << "[*] Writing output..." << endl;
+
+	for (unsigned int blockIndex = 0; blockIndex < (*charCounts).size(); blockIndex++) {
+		vector<int> charIndexTemp = charIndexRef;
+		if (stoi(options["SORTED"]) != 0) {
+			sort_arrays(&((*charCounts)[blockIndex]), &charIndexTemp);
+		}
+
+		(*out) << "Ngram for block index " << blockIndex << ": " << endl;
+		
+		for (unsigned int charIndex = 0; charIndex < (*charCounts)[blockIndex].size(); charIndex++) {
+			if (stoi(options["SHOWFREQUENCY"]) == 0) {
+				int numSpaces = 0, temp = (*charCounts)[blockIndex][charIndex];
+				while (temp /= 10) numSpaces++;
+				numSpaces = (*maxLength)[blockIndex] - numSpaces;
+				(*out) << charIndexTemp[charIndex] << "," << string(numSpaces + 1, ' ') << (*charCounts)[blockIndex][charIndex] << "; \n";
+			}
+			else {
+				float percent = ((float)(*charCounts)[blockIndex][charIndex] / (float)(*charTotal)[blockIndex]) * 100;
+				(*out) << fixed << charIndexTemp[charIndex] << ", "<< percent << "; \n";
+			}
+		}
+	}
+
+	return 0;
+}
+
+int Ngram::sort_arrays(vector<int>* charCounts, vector<int>* charIndexArray) {
+	for (unsigned int mainIndex = 0; mainIndex < (*charCounts).size(); mainIndex++) {
+		int countValue = (*charCounts)[mainIndex],
+			countIndex = (*charIndexArray)[mainIndex],
+			swapIndex = mainIndex - 1;
+
+		while (swapIndex >= 0 && (*charCounts)[swapIndex] < countValue) {
+			(*charCounts)[swapIndex + 1] = (*charCounts)[swapIndex];
+			(*charIndexArray)[swapIndex + 1] = (*charIndexArray)[swapIndex];
+			swapIndex--;
+		}
+
+		(*charCounts)[swapIndex + 1] = countValue;
+		(*charIndexArray)[swapIndex + 1] = countIndex;
+	}
+
+	return 0;
+}

--- a/src/attacks/ngram.cpp
+++ b/src/attacks/ngram.cpp
@@ -14,11 +14,10 @@ Ngram::Ngram()
     set_opts(temp);
 
     // set default values, option must exist or error will printed
-	set_opt_value("INPUTFILE", "makefile");
     set_opt_value("OUTPUTFILE", "ngram");
 	set_opt_value("N-SIZE", "2");
 	set_opt_value("CHARSETSIZE", "256");
-	set_opt_value("MINOCCURENCES", "2");
+	set_opt_value("MINOCCURENCES", "20");
 	set_opt_value("OUTPUTHEX", "0");
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ void register_modules(map<string,Module*> &m)
     // registration, copy this for new modules
     m.insert(make_pair("attacks/example", new Example()));
 	m.insert(make_pair("attacks/histogram", new Histogram()));
+	m.insert(make_pair("attacks/ngram", new Ngram()));
     m.insert(make_pair("attacks/caesar", new CaesarAttack()));
     m.insert(make_pair("ciphers/caesar", new Caesar()));
     m.insert(make_pair("ciphers/vigenere", new Vigenere()));


### PR DESCRIPTION
Implements utility to analyze digrams, trigrams, etc. Inherently slow starting at quadgrams, simply due to exponential growth of space requirements in the length of the n-gram. 

Allows setting minimum number of occurrences before adding to the output file. Allows variable length of gram analysis. Allows CSV to be output in a series of hex or int representations.

Includes relevant fix for histogram generation to handle extended ascii properly.